### PR TITLE
Patch for call_with_list

### DIFF
--- a/common.py
+++ b/common.py
@@ -88,6 +88,12 @@ def call_with_list(command, envir=None, verbose=True):
     while helper.poll() is None:
         output = helper.stdout.readline()
         res += output
+        time.sleep(0.1) # TODO What is a good value here? Without this delay it's busy looping
+
+    #make sure to capture the last line(s)
+    output = helper.stdout.read()
+    res += output
+    
     if verbose:
         print res
     if helper.returncode != 0:


### PR DESCRIPTION
This should resolve:  ros-infrastructure/jenkins_tools/issues/9

The primary fix is to not print every cycle as printing causes new lines even if there's no new output.  It no longer outputs things line by line, but there's no need to do that.  

This also gets rid of the busy wait and make sure to catch the last elements.  
