### PR TITLE
using rosdep db --install-method apt

### DIFF
--- a/rosdep.py
+++ b/rosdep.py
@@ -23,7 +23,7 @@ class RosDepResolver:
             call("rosdep update", self.env)
 
         print("Building dictionaries from a rosdep's db")
-        raw_db = check_output("rosdep db", self.env, verbose=False).split('\n')
+        raw_db = check_output("rosdep db --install-method apt", self.env, verbose=False).split('\n')
 
         for entry in raw_db:
             split_entry = entry.split(' -> ')


### PR DESCRIPTION
use `rosdep db --install-method apt` to build dictionaries only for apt installable packages, (to ignore pip install rosdep keys), need to use this PR https://github.com/ros-infrastructure/rosdep/pull/374/files